### PR TITLE
Add crossOrigin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ avoid additional network requests.
 await loadImage("test.jpg", { useCache: true });
 ```
 
+# crossOrigin
+You can configure to use a cross-origin request with `crossOrigin` set to `anonymous`.
+See [HTMLImageElement.crossOrigin](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin) for details.
+```js
+await loadImage("test.jpg", { crossOrigin: "anonymous" });
+```
+
 # timeout
 You can limit how long to wait for an image to load in milliseconds by setting timeout to a number.
 ```js

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var loadImageCache = {};
 function loadImage(url, options) {
   var debug = (options && options.debug) || false;
   var useCache = (options && options.useCache) || false;
+  var crossOrigin = (options && options.crossOrigin) || null;
   if (debug) console.log("[easy-image-loader] starting to load", url);
 
   if (useCache && loadImageCache[url]) return loadImageCache[url];
@@ -21,6 +22,7 @@ function loadImage(url, options) {
       reject(error);
     };
     img.src = url;
+    img.crossOrigin = crossOrigin;
     if (options && typeof options.timeout === "number") {
       setTimeout(() => {
         if (debug) console.error("[easy-image-loader] timed out loading", url);


### PR DESCRIPTION
Currently loading cross-origin images fails, because img element uses a no-cors mode by default.

Adding a crossOrigin option to this library allows rendering cross-origin images with stac-layer at https://github.com/stac-utils/stac-layer/blob/main/src/utils/image-overlay.js#L11 (add `crossOrigin: "anonymous"`) and stac-browser.